### PR TITLE
[Connectionpool 활용하기] 알린(장원영)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@
 - [servlet](./servlet/README.md)
 - reflection
 - [di](./di/README.md)
+- [connectionPool](./connectionpool/READMD.md)

--- a/connectionpool/READMD.md
+++ b/connectionpool/READMD.md
@@ -1,0 +1,37 @@
+# **학습 목표**
+
+- 애플리케이션이 필요로 할 때마다 매번 DB에 물리적 연결(Connection)을 만들면 시간과 리소스가 많이 사용된다.
+- 서버 성능을 높이기 위해 Connection Pool을 사용하자.
+- Connection Pool은 DB로부터 미리 Connection을 만들어 보관한다.
+
+# **학습 순서**
+
+- JDBC 드라이버를 사용하여 데이터베이스에 연결하는 방법을 살펴본다.
+- HikariCP가 어떤 것인지 다뤄보고 공식 문서를 읽어본다.
+- MaximumPoolSize를 몇으로 설정하면 좋을지 고민하고 적용한다.
+
+# **저장소**
+
+- jwp-hands-on
+    - [connection pool](https://github.com/woowacourse/jwp-hands-on/tree/main/connectionpool)
+
+# **0단계 - DataSource 다루기**
+
+- 자바에서 제공하는 JDBC 드라이버를 직접 다뤄본다.
+- 데이터베이스에 어떻게 연결하는지, 그리고 왜 DataSource를 사용하는지 찾아보자.
+
+# **1단계 - 커넥션 풀링**
+
+- 커넥션 풀링이 무엇인지 h2의 JdbcConnectionPool을 직접 다뤄본다.
+    - JdbcConnectionPool 클래스가 복잡하지 않으니 직접 분석해봐도 좋다.
+- 왜 스프링 부트에서 HikariCP를 사용하는지 찾아본다.
+    - [spring boot docs](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#data.sql.datasource.connection-pool)
+- 그리고 HikariCP에 어떤 설정을 하면 좋을지 공식 문서를 읽어보자.
+    - [HikariCP](https://github.com/brettwooldridge/HikariCP#rocket-initialization)
+    - [About Pool Sizing](https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing)
+    - [MySQL Configuration](https://github.com/brettwooldridge/HikariCP/wiki/MySQL-Configuration)
+
+# **2단계 - HikariCP 설정하기**
+
+- 스프링 부트로 HikariCP를 설정하는 방법을 익힌다.
+- 커넥션 풀이 의도한대로 동작하는지 테스트한다.

--- a/connectionpool/src/main/java/jdbc/DataSourceConfig.java
+++ b/connectionpool/src/main/java/jdbc/DataSourceConfig.java
@@ -21,8 +21,6 @@ public class DataSourceConfig {
         final var hikariConfig = new HikariConfig();
         hikariConfig.setPoolName("gugu");
         hikariConfig.setJdbcUrl(H2_URL);
-        hikariConfig.setUsername(USER);
-        hikariConfig.setPassword(PASSWORD);
         hikariConfig.setMaximumPoolSize(MAXIMUM_POOL_SIZE);
         hikariConfig.setConnectionTestQuery("VALUES 1");
         hikariConfig.addDataSourceProperty("cachePrepStmts", "true");

--- a/connectionpool/src/test/java/jdbc/stage0/Stage0Test.java
+++ b/connectionpool/src/test/java/jdbc/stage0/Stage0Test.java
@@ -1,5 +1,7 @@
 package jdbc.stage0;
 
+import java.sql.DriverManager;
+import jdbc.DataSourceConfig;
 import org.h2.jdbcx.JdbcDataSource;
 import org.junit.jupiter.api.Test;
 
@@ -29,7 +31,7 @@ class Stage0Test {
     void driverManager() throws SQLException {
         // Class.forName("org.h2.Driver"); // JDBC 4.0 부터 생략 가능
         // DriverManager 클래스를 활용하여 static 변수의 정보를 활용하여 h2 db에 연결한다.
-        try (final Connection connection = null) {
+        try (final Connection connection = DriverManager.getConnection(H2_URL)) {
             assertThat(connection.isValid(1)).isTrue();
         }
     }
@@ -49,7 +51,8 @@ class Stage0Test {
      */
     @Test
     void dataSource() throws SQLException {
-        final JdbcDataSource dataSource = null;
+        final JdbcDataSource dataSource = new JdbcDataSource();
+        dataSource.setURL(H2_URL);
 
         try (final var connection = dataSource.getConnection()) {
             assertThat(connection.isValid(1)).isTrue();

--- a/connectionpool/src/test/java/jdbc/stage1/Stage1Test.java
+++ b/connectionpool/src/test/java/jdbc/stage1/Stage1Test.java
@@ -1,13 +1,14 @@
 package jdbc.stage1;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
-import org.h2.jdbcx.JdbcConnectionPool;
-import org.junit.jupiter.api.Test;
-
 import java.sql.SQLException;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import java.util.Properties;
+import org.h2.jdbcx.JdbcConnectionPool;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.Test;
 
 class Stage1Test {
 
@@ -28,7 +29,9 @@ class Stage1Test {
      */
     @Test
     void testJdbcConnectionPool() throws SQLException {
-        final JdbcConnectionPool jdbcConnectionPool = null;
+        final JdbcDataSource dataSource = new JdbcDataSource();
+        dataSource.setURL(H2_URL);
+        final JdbcConnectionPool jdbcConnectionPool = JdbcConnectionPool.create(dataSource);
 
         assertThat(jdbcConnectionPool.getActiveConnections()).isZero();
         try (final var connection = jdbcConnectionPool.getConnection()) {
@@ -61,6 +64,11 @@ class Stage1Test {
     @Test
     void testHikariCP() {
         final var hikariConfig = new HikariConfig();
+        hikariConfig.setJdbcUrl(H2_URL);
+        hikariConfig.setMaximumPoolSize(5);
+        hikariConfig.addDataSourceProperty("cachePrepStmts", "true");
+        hikariConfig.addDataSourceProperty("prepStmtCacheSize", "250");
+        hikariConfig.addDataSourceProperty("prepStmtCacheSqlLimit", "2048");
 
         final var dataSource = new HikariDataSource(hikariConfig);
         final var properties = dataSource.getDataSourceProperties();

--- a/connectionpool/src/test/java/jdbc/stage2/Stage2Test.java
+++ b/connectionpool/src/test/java/jdbc/stage2/Stage2Test.java
@@ -49,10 +49,10 @@ class Stage2Test {
         }
 
         // 동시에 많은 요청이 몰려도 최대 풀 사이즈를 유지한다.
-        assertThat(hikariPool.getTotalConnections()).isEqualTo(0);
+        assertThat(hikariPool.getTotalConnections()).isEqualTo(((HikariDataSource) dataSource).getMaximumPoolSize());
 
         // DataSourceConfig 클래스에서 직접 생성한 커넥션 풀.
-        assertThat(hikariDataSource.getPoolName()).isEqualTo("");
+        assertThat(hikariDataSource.getPoolName()).isEqualTo("gugu");
     }
 
     // 데이터베이스에 연결만 하는 메서드. 커넥션 풀에 몇 개의 연결이 생기는지 확인하는 용도.


### PR DESCRIPTION
# **학습 목표**

- 애플리케이션이 필요로 할 때마다 매번 DB에 물리적 연결(Connection)을 만들면 시간과 리소스가 많이 사용된다.
- 서버 성능을 높이기 위해 Connection Pool을 사용하자.
- Connection Pool은 DB로부터 미리 Connection을 만들어 보관한다.

# **학습 순서**

- JDBC 드라이버를 사용하여 데이터베이스에 연결하는 방법을 살펴본다.
- HikariCP가 어떤 것인지 다뤄보고 공식 문서를 읽어본다.
- MaximumPoolSize를 몇으로 설정하면 좋을지 고민하고 적용한다.

# **저장소**

- jwp-hands-on
    - [connection pool](https://github.com/woowacourse/jwp-hands-on/tree/main/connectionpool)

# **0단계 - DataSource 다루기**

- 자바에서 제공하는 JDBC 드라이버를 직접 다뤄본다.
- 데이터베이스에 어떻게 연결하는지, 그리고 왜 DataSource를 사용하는지 찾아보자.

# **1단계 - 커넥션 풀링**

- 커넥션 풀링이 무엇인지 h2의 JdbcConnectionPool을 직접 다뤄본다.
    - JdbcConnectionPool 클래스가 복잡하지 않으니 직접 분석해봐도 좋다.
- 왜 스프링 부트에서 HikariCP를 사용하는지 찾아본다.
    - [spring boot docs](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#data.sql.datasource.connection-pool)
- 그리고 HikariCP에 어떤 설정을 하면 좋을지 공식 문서를 읽어보자.
    - [HikariCP](https://github.com/brettwooldridge/HikariCP#rocket-initialization)
    - [About Pool Sizing](https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing)
    - [MySQL Configuration](https://github.com/brettwooldridge/HikariCP/wiki/MySQL-Configuration)

# **2단계 - HikariCP 설정하기**

- 스프링 부트로 HikariCP를 설정하는 방법을 익힌다.
- 커넥션 풀이 의도한대로 동작하는지 테스트한다.